### PR TITLE
API "Client-ID" Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ program
     .action(function (streamer) {
         request
             .post('https://api.twitch.tv/kraken/streams/' + streamer)
+            .set('Client-ID', '3zzmx0l2ph50anf78iefr6su9d8byj8')
             .set('Accept', 'application/json')
             .end(function (err, res) {
                 var stream = JSON.parse(res.text).stream,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-stream-check",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "A simple command line tool to check to see if a Twitch user is streaming or not",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
As of August 8th, 2016, the Twitch API required the "Client-ID" header to be set for all API calls. It's taken almost 2 and a half months to correct this within the CLI, but it's here in 1.2.0. Here's the scoop:
- The client ID of my registered twitch-stream-check app is now set when requesting the API
- Fixes issue #1 
